### PR TITLE
Add support for proxied records

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ CF_API_TOKEN = token_key_here
 2. Copy `Zone ID`
 3. Edit like sample
 
-Note: `@` will be same as `base_domain`
+Notes: 
+  - `@` will be same as `base_domain`
+  - To proxy a record, include it in both `records` and `proxied_records`
 
 ### Auto running
 

--- a/cf-dns-update.py
+++ b/cf-dns-update.py
@@ -126,6 +126,7 @@ def update_host(zone_id, record_name, public_ip, is_proxied):
     :param zone_id:
     :param record_name:
     :param public_ip:
+    :param is_proxied:
     :return:
     """
     record_id = get_record_id(zone_id, record_name)

--- a/cf-dns-update.py
+++ b/cf-dns-update.py
@@ -204,7 +204,7 @@ def process_section(section_data, public_ip):
     """
     base_domain = section_data["base_domain"].strip()
     record_list = section_data["records"].strip().split("|")
-    proxied_record_list = section_data["proxied_records"].strip().split("|")
+    proxied_record_list = section_data["proxied_records"].strip().split("|") if "proxied_records" in section_data else ""
 
     for record in record_list:
         record = record.strip()

--- a/cf-dns-update.py
+++ b/cf-dns-update.py
@@ -119,7 +119,7 @@ def get_record_id(zone_id, record_name):
     return False
 
 
-def update_host(zone_id, record_name, public_ip):
+def update_host(zone_id, record_name, public_ip, is_proxied):
     """
     Update host to CloudFlare
 
@@ -142,7 +142,8 @@ def update_host(zone_id, record_name, public_ip):
     payload = {
         "type": "A",
         "name": record_name,
-        "content": public_ip
+        "content": public_ip,
+        "proxied": is_proxied
     }
 
     response = make_request(
@@ -203,10 +204,12 @@ def process_section(section_data, public_ip):
     """
     base_domain = section_data["base_domain"].strip()
     record_list = section_data["records"].strip().split("|")
+    proxied_record_list = section_data["proxied_records"].strip().split("|")
 
     for record in record_list:
         record = record.strip()
         dns_record = base_domain
+        is_proxied = False
         if record != '@':
             dns_record = "{}.{}".format(record, base_domain)
 
@@ -214,7 +217,10 @@ def process_section(section_data, public_ip):
             print("[DRY RUN] Update record `{}` in zone id `{}`".format(dns_record, section_data['zone_id']))
             continue
 
-        update_host(section_data['zone_id'], dns_record, public_ip)
+        if record in proxied_record_list:
+            is_proxied = True
+
+        update_host(section_data['zone_id'], dns_record, public_ip, is_proxied)
 
 
 def main(args):

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -11,4 +11,3 @@ proxied_records = @|test2
 zone_id = xxx
 base_domain = nhymxu.info
 records = yyy|zzz
-proxied_records = 

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -5,8 +5,10 @@ CF_API_TOKEN = xxx
 zone_id = xxx
 base_domain = dungnt.net
 records = @|test1|test2
+proxied_records = @|test2
 
 [nhymxu.info-test-section]
 zone_id = xxx
 base_domain = nhymxu.info
 records = yyy|zzz
+proxied_records = 


### PR DESCRIPTION
This pull request adds support to proxy records, and it's backwards compatible with old configuration files

To enable the HTTP proxy in a record just add its base domain or subdomain to both `records` and `proxied_records`, here is a full example:
```ini
[common]
CF_API_TOKEN = xxx

[dungnt.net-test-section]
zone_id = xxx
base_domain = dungnt.net
records = @|test1|test2
proxied_records = @|test2

[nhymxu.info-test-section]
zone_id = xxx
base_domain = nhymxu.info
records = yyy|zzz
```

This will result in:
- `dungnt.net` being proxied
- `test1.dungnt.net` **NOT** being proxied
- `test2.dungnt.net` being proxied
- `yyy.nhymxu.info` **NOT** being proxied
- `zzz.nhymxu.info` **NOT** being proxied
